### PR TITLE
Updated proposition extraction memory block and reductive agent to be compatible with Qdrant through docker

### DIFF
--- a/asdrp/agent/reductive_agent.py
+++ b/asdrp/agent/reductive_agent.py
@@ -23,7 +23,6 @@ from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
 from asdrp.agent.BaseAgent import BaseAgent
-from llama_index.llms.openai import OpenAI
 import time
 import asyncio
 from asdrp.agent.base import AgentReply
@@ -39,10 +38,11 @@ class ReductiveAgent(BaseAgent):
         try:
             initial_query_time = time.time()
             user_message = ChatMessage(role=MessageRole.USER, content=user_msg)
-            await self.memory_block._aput(messages=[user_message])
 
             # Prepend known propositions to the user message if available, with explicit instruction
             props = await self.memory_block._aget(messages=[user_message])
+            if not props:
+                return AgentReply(response_str="ERROR: NO PROPOSITIONS STORED")
 
             prompt = (
                 f"User: {user_msg}\n"

--- a/asdrp/agent/reductive_agent.py
+++ b/asdrp/agent/reductive_agent.py
@@ -10,34 +10,39 @@
 #   @author     Eric Vincent Fernandes
 #               - Implemented tracking for token/cost metrics
 #               - Modified code to be compatible with Gemini (GenAI)
+#   @author     Varenya Garg
+#               - Modified code to store and retrieve propositions using Qdrant vector database
 #
 # Date:
 #   Created:    July 4, 2025  (Theodore Mui)
 #   Modified:   October 5, 2025 (Eric Vincent Fernandes)
+#   Modified:   April 5, 2026 (Varenya Garg)
 #############################################################################
 
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
 from asdrp.agent.BaseAgent import BaseAgent
-
+from llama_index.llms.openai import OpenAI
 import time
 import asyncio
 from asdrp.agent.base import AgentReply
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from asdrp.memory.proposition_extraction_memory import PropositionExtractionMemoryBlock
 
 class ReductiveAgent(BaseAgent):
     def __init__(self):
-        self.memory_block = PropositionExtractionMemoryBlock(max_propositions=50)
+        super().__init__()
+        self.memory_block = PropositionExtractionMemoryBlock(collection="agent_condensed_mem", max_propositions=50)
 
     async def achat(self, user_msg: str) -> AgentReply:
         try:
             initial_query_time = time.time()
+            user_message = ChatMessage(role=MessageRole.USER, content=user_msg)
+            await self.memory_block._aput(messages=[user_message])
 
             # Prepend known propositions to the user message if available, with explicit instruction
-            props = await self.memory_block._aget()
-            if not props:
-                return AgentReply(response_str="ERROR: NO PROPOSITIONS STORED")
+            props = await self.memory_block._aget(messages=[user_message])
 
             prompt = (
                 f"User: {user_msg}\n"

--- a/asdrp/agent/summary_agent.py
+++ b/asdrp/agent/summary_agent.py
@@ -26,7 +26,7 @@ from typing import List
 from llama_index.core.agent.workflow import FunctionAgent, AgentOutput
 from llama_index.core.callbacks import CallbackManager, TokenCountingHandler
 from llama_index.core.utils import count_tokens
-from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.tools import FunctionTool
 from llama_index.core.llms import LLM
 from llama_index.core.memory import (Memory, InsertMethod)
@@ -90,11 +90,13 @@ class SummaryAgent:
     async def achat(self, user_msg: str) -> AgentReply:
         try:
 
-            full_msg = user_msg + str(await self.memory_block._aget())
+            user_message = ChatMessage(role=MessageRole.USER, content=user_msg)
+
+            full_msg = user_msg + str(await self.memory_block._aget(messages=[user_message]))
 
             # Count tokens passed into the LLM within this agent
             self.query_input_tokens = count_tokens(full_msg)
-
+            
             initial_query_time = time.time()
 
             response = await self.agent.run(user_msg=user_msg, memory=self.memory)

--- a/asdrp/memory/condensed_memory.py
+++ b/asdrp/memory/condensed_memory.py
@@ -18,11 +18,18 @@
 
 import time
 from typing import Any, List, Optional
-
+import qdrant_client
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client.models import Distance, VectorParams, PointIdsList
+from llama_index.core.schema import TextNode
+from llama_index.core import VectorStoreIndex, StorageContext, Settings
 from llama_index.core.llms import ChatMessage, TextBlock
 from llama_index.core.memory import BaseMemoryBlock
 from llama_index.core.utils import count_tokens
 from pydantic import Field
+import json
 
 DEFAULT_TOKEN_LIMIT = 60000
 
@@ -36,6 +43,40 @@ class CondensedMemoryBlock(BaseMemoryBlock[str]):
 
     It also includes additional kwargs, like tool calls, when needed.
     """
+
+    def __init__(self, 
+    collection: str = "agent_condensed_mem",
+    host: str = "localhost", 
+    port: int = 6333,
+    **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self._collection = collection
+        # Connect to the Qdrant collection
+        self._client = qdrant_client.QdrantClient(host=host, port=port)
+        self._aclient = qdrant_client.AsyncQdrantClient(host=host, port=port)
+        # Check if there is an existing collection 
+        existing = [c.name for c in self._client.get_collections().collections]
+        # Create a new collection if none exists
+        if self._collection not in existing:
+            self._client.create_collection(
+                collection_name=self._collection,
+                vectors_config=VectorParams(
+                    size=1536,        # must match embedding model's output
+                    distance=Distance.COSINE
+                )
+            )
+
+        self._vector_store = QdrantVectorStore(client = self._client, collection_name=collection, aclient=self._aclient)
+       
+        Settings.llm = OpenAI(model="o4-mini")
+        Settings.embed_model = OpenAIEmbedding(model="text-embedding-3-small")
+        
+        self._storage_ctx = StorageContext.from_defaults(vector_store=self._vector_store)
+
+        self._index = VectorStoreIndex(nodes=[], storage_context = self._storage_ctx)
+
+
     current_memory: List[str] = Field(default_factory=list)
     token_limit: int = Field(default=DEFAULT_TOKEN_LIMIT)
     input_tokens: int = Field(default=0, description="The number of tokens passed into the LLM when loading the chat history.")
@@ -46,7 +87,29 @@ class CondensedMemoryBlock(BaseMemoryBlock[str]):
         self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any
     ) -> str:
         """Return the current memory block contents."""
-        return "\n".join(self.current_memory)
+        if messages is None:
+            return ""
+
+        # Use most recent query as the search query
+        query = messages[-1].content
+        query_vector = await Settings.embed_model.aget_text_embedding(query)
+        top_k = block_kwargs.get("top_k", 3)
+        
+        results = self._client.query_points(
+                collection_name=self._collection,
+                query=query_vector,
+                limit=top_k,
+                with_payload=True
+            ).points
+
+        
+        if not results: 
+            return ""
+        
+        return "\n".join([
+            json.loads(point.payload["_node_content"])["text"] 
+            for point in results
+        ])
 
     async def _aput(self, messages: List[ChatMessage]) -> None:
         """Push messages into the memory block. (Only handles text content)"""
@@ -80,14 +143,38 @@ class CondensedMemoryBlock(BaseMemoryBlock[str]):
                     kwargs[key] = val
             memory_str += f"\n({kwargs})" if kwargs else ""
 
-            self.current_memory.append(memory_str)
+            nodes = TextNode(text=memory_str) 
+            await self._index.ainsert_nodes(nodes)
+
 
             # Count tokens for this new message (input tokens)
+            results, _ = self._aclient.scroll(
+                collection_name=self._collection,
+                limit=1000,
+                with_payload=True
+            )
 
+            all_messages = "".join([
+            json.loads(point.payload["_node_content"])["text"] 
+            for point in results
+        ])
         # ensure this memory block doesn't get too large
-        message_length = sum(count_tokens(message) for message in self.current_memory)
+        message_length = count_tokens(all_messages)
         while message_length > self.token_limit:
-            self.current_memory = self.current_memory[1:]
-            message_length = sum(count_tokens(message) for message in self.current_memory)
+            oldest_point = results[0].id
+
+            self._client.delete(
+                collection_name = self._collection,
+                points_selector = PointIdsList(points = [oldest_point])
+            )
+
+            results = results[1:]
+
+            all_messages = "".join([
+                json.loads(point.payload["_node_content"])["text"] 
+                for point in results
+            ])
+
+            message_length = count_tokens(all_messages)
 
         self.load_chat_history_time = time.time() - start_time

--- a/asdrp/memory/proposition_extraction_memory.py
+++ b/asdrp/memory/proposition_extraction_memory.py
@@ -110,7 +110,7 @@ class PropositionExtractionMemoryBlock(BaseMemBlock):
     """
 
     def __init__(self, 
-    collection: str = "agent_condensed_mem",
+    collection: str = "agent_proposition_mem",
     host: str = "localhost", 
     port: int = 6333,
     **kwargs: Any
@@ -127,7 +127,7 @@ class PropositionExtractionMemoryBlock(BaseMemBlock):
             self._client.create_collection(
                 collection_name=self._collection,
                 vectors_config=VectorParams(
-                    size=1536,        # must match your embedding model's output
+                    size=1536,        # must match embedding model's output
                     distance=Distance.COSINE
                 )
             )
@@ -186,14 +186,13 @@ class PropositionExtractionMemoryBlock(BaseMemBlock):
                 with_payload=True
             ).points
 
- 
         
         if not results: 
             return ""
         
         return "\n".join([
-            json.loads(r.payload["_node_content"])["text"] 
-            for r in results
+            json.loads(point.payload["_node_content"])["text"] 
+            for point in results
         ])
 
 

--- a/asdrp/memory/proposition_extraction_memory.py
+++ b/asdrp/memory/proposition_extraction_memory.py
@@ -10,18 +10,30 @@
 #   @author     Eric Vincent Fernandes
 #               - Implemented tracking for token/cost metrics
 #               - Modified code to be compatible with Gemini (GenAI)
+#   @author     Varenya Garg
+#               - Modified code to store and retrieve propositions using Qdrant vector database
 #
 # Date:
 #   Created:    July 4, 2025  (Theodore Mui)
 #   Modified:   October 16, 2025 (Eric Vincent Fernandes)
+#   Modified:   April 5, 2026 (Varenya Garg)
 #############################################################################
 
 import time
+import qdrant_client
+from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client.models import Distance, VectorParams
+from llama_index.core.schema import TextNode
+from llama_index.core import VectorStoreIndex, Document, StorageContext, Settings
 from typing import Any, List, Optional, Union
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.bridge.pydantic import Field, field_validator
 from llama_index.core.prompts import (BasePromptTemplate, PromptTemplate, RichPromptTemplate)
 from asdrp.memory.BaseMemBlock import BaseMemBlock
+import json
+
 
 DEFAULT_EXTRACT_PROMPT = RichPromptTemplate("""
 You are a precise proposition extraction system designed to identify key information from conversations.
@@ -97,21 +109,53 @@ class PropositionExtractionMemoryBlock(BaseMemBlock):
     structuring them in XML format for easy parsing and retrieval.
     """
 
-    _propositions: List[str] = Field(
-        default_factory = list,
-        description = "List of extracted propositions from the conversation."
-    )
+    def __init__(self, 
+    collection: str = "agent_condensed_mem",
+    host: str = "localhost", 
+    port: int = 6333,
+    **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self._collection = collection
+        # Connect to the Qdrant collection
+        self._client = qdrant_client.QdrantClient(host=host, port=port)
+        self._aclient = qdrant_client.AsyncQdrantClient(host=host, port=port)
+        # Check if there is an existing collection 
+        existing = [c.name for c in self._client.get_collections().collections]
+        # Create a new collection if none exists
+        if self._collection not in existing:
+            self._client.create_collection(
+                collection_name=self._collection,
+                vectors_config=VectorParams(
+                    size=1536,        # must match your embedding model's output
+                    distance=Distance.COSINE
+                )
+            )
+
+        self._vector_store = QdrantVectorStore(client = self._client, collection_name=collection, aclient=self._aclient)
+       
+        Settings.llm = OpenAI(model="o4-mini")
+        Settings.embed_model = OpenAIEmbedding(model="text-embedding-3-small")
+        
+        self._storage_ctx = StorageContext.from_defaults(vector_store=self._vector_store)
+
+        self._index = VectorStoreIndex(nodes=[], storage_context = self._storage_ctx)
+
+
+
+
     max_propositions: int = Field(
         default = 50, description = "The maximum number of propositions to store."
     )
-    _proposition_extraction_prompt_template: BasePromptTemplate = Field(
+    proposition_extraction_prompt_template: BasePromptTemplate = Field(
         default = DEFAULT_EXTRACT_PROMPT,
         description = "Template for the proposition extraction prompt."
     )
-    _proposition_condense_prompt_template: BasePromptTemplate = Field(
+    proposition_condense_prompt_template: BasePromptTemplate = Field(
         default = DEFAULT_CONDENSE_PROMPT,
         description = "Template for the proposition condense prompt."
     )
+
 
     @field_validator("proposition_extraction_prompt_template", mode = "before")
     @classmethod
@@ -127,10 +171,31 @@ class PropositionExtractionMemoryBlock(BaseMemBlock):
 
     async def _aget(self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any) -> str:
         """Return the current propositions as formatted text."""
-        if not self._propositions:
+        if messages is None:
             return ""
 
-        return "\n".join([f"{proposition}" for proposition in self._propositions])
+        # Use most recent query as the search query
+        query = messages[-1].content
+        query_vector = await Settings.embed_model.aget_text_embedding(query)
+        top_k = block_kwargs.get("top_k", 3)
+        
+        results = self._client.query_points(
+                collection_name=self._collection,
+                query=query_vector,
+                limit=top_k,
+                with_payload=True
+            ).points
+
+ 
+        
+        if not results: 
+            return ""
+        
+        return "\n".join([
+            json.loads(r.payload["_node_content"])["text"] 
+            for r in results
+        ])
+
 
     async def _aput(self, messages: List[ChatMessage]) -> None:
         """Extract propositions from new messages and add them to the propositions list."""
@@ -142,48 +207,52 @@ class PropositionExtractionMemoryBlock(BaseMemBlock):
         # Track before call
         start_time = time.time()
 
-        # Format existing propositions for the prompt
-        existing_propositions_text = ""
-        if self._propositions:
-            existing_propositions_text = "\n".join([f"{proposition}" for proposition in self._propositions])
+        # Get existing propositions
+        results = self._client.scroll(
+            collection_name=self._collection,
+            limit=self.max_propositions,
+            with_payload=True
+        )
+        existing_propositions = [json.loads(point.payload["_node_content"])["text"] for point in results[0]]
+        existing_propositions_text = "\n".join(existing_propositions)
 
         conversation_text = "\n".join([m.content for m in messages])
-
-        # Create the prompt
-        prompt_messages = self._proposition_extraction_prompt_template.format(max_propositions = self.max_propositions, conversation_segment = conversation_text, existing_propositions = existing_propositions_text)
-
+        prompt_messages = self.proposition_extraction_prompt_template.format(
+            max_propositions = self.max_propositions, 
+            conversation_segment = conversation_text, 
+            existing_propositions = existing_propositions_text)
+        
         # Get the propositions extraction
         response = await self.llm.acomplete(prompt_messages)
         propositions_text = "" if response.text == "NO NEW PROPOSITIONS" else response.text
         new_propositions = [line.strip() for line in propositions_text.strip().splitlines() if line.strip()]
 
-        # Count input tokens
         self.input_tokens += int(len(prompt_messages) / 4)
         self.output_tokens += int(len(propositions_text) / 4)
 
-        # Add new propositions to the list, avoiding exact-match duplicates
-        for proposition in new_propositions:
-            if proposition not in self._propositions:
-                self._propositions.append(proposition)
-
-        # Condense the propositions if they exceed the max_propositions
-        if len(self._propositions) >= self.max_propositions:
-            existing_propositions_text = "\n".join([f"{proposition}" for proposition in self._propositions])
-
-            prompt_messages = self._proposition_condense_prompt_template.format(
+        if new_propositions:
+            # Add new propositions to the index
+            nodes = [TextNode(text=proposition) for proposition in new_propositions]
+            await self._index.ainsert_nodes(nodes)
+        
+        total_count = self._client.count(collection_name=self._collection).count
+        if total_count >= self.max_propositions: 
+            # Condense the propositions if they exceed the max_propositions
+            prompt_messages = self.proposition_condense_prompt_template.format(
                 max_propositions = self.max_propositions,
                 existing_propositions = existing_propositions_text
             )
             response = await self.llm.acomplete(prompt_messages)
             propositions_text = "" if response.text == "NO CONDENSED PROPOSITIONS" else response.text
-            new_propositions = [line.strip() for line in propositions_text.strip().splitlines() if line.strip()]
+            condensed_propositions = [line.strip() for line in propositions_text.strip().splitlines() if line.strip()]
 
-            # count tokens for condense output
             self.input_tokens += int(len(existing_propositions_text) / 4)
             self.output_tokens += int(len(propositions_text) / 4)
 
-            # Replace the propositions with the condensed list
-            if new_propositions:
-                self._propositions = new_propositions
+            if condensed_propositions:
+                # Delete the existing collection and add the condensed propositions
+                self._client.delete_collection(collection_name=self._collection)
+                nodes = [TextNode(text=proposition) for proposition in condensed_propositions]
+                await self._index.ainsert_nodes(nodes)
 
         self.load_chat_history_time = time.time() - start_time


### PR DESCRIPTION
### **Migrate proposition storage from list to Qdrant vector database**

- Replace _propositions list with Qdrant-backed VectorStoreIndex
- Add QdrantClient and AsyncQdrantClient setup in __init__
- Auto-create Qdrant collection on initialization if not present
- Update _aput to store propositions as TextNode objects via ainsert_nodes
- Update _aput to fetch existing propositions via scroll instead of list
- Update _aget to use query_points for semantic similarity search
- Embed queries manually via Settings.embed_model before searching
- Fix payload key to _node_content to extract text from LlamaIndex format
- Wrap user messages as ChatMessage before passing to _aput and _aget

**Requires Qdrant running locally via Docker on port 6333**